### PR TITLE
ARQ-1797: Screenshot annotation made part of fired TakeScreenShot event

### DIFF
--- a/arquillian-recorder-screenshooter-base/arquillian-recorder-screenshooter-impl-base/src/main/java/org/arquillian/extension/recorder/screenshooter/impl/ScreenshooterLifecycleObserver.java
+++ b/arquillian-recorder-screenshooter-base/arquillian-recorder-screenshooter-impl-base/src/main/java/org/arquillian/extension/recorder/screenshooter/impl/ScreenshooterLifecycleObserver.java
@@ -25,6 +25,7 @@ import org.arquillian.extension.recorder.screenshooter.Screenshooter;
 import org.arquillian.extension.recorder.screenshooter.ScreenshooterConfiguration;
 import org.arquillian.extension.recorder.screenshooter.ScreenshotMetaData;
 import org.arquillian.extension.recorder.screenshooter.ScreenshotType;
+import org.arquillian.extension.recorder.screenshooter.api.Screenshot;
 import org.arquillian.extension.recorder.screenshooter.event.AfterScreenshotTaken;
 import org.arquillian.extension.recorder.screenshooter.event.BeforeScreenshotTaken;
 import org.arquillian.extension.recorder.screenshooter.event.TakeScreenshot;
@@ -75,7 +76,7 @@ public class ScreenshooterLifecycleObserver {
 
             beforeScreenshotTaken.fire(new BeforeScreenshotTaken(metaData));
 
-            takeScreenshot.fire(new TakeScreenshot(screenshotName, metaData, When.BEFORE));
+            takeScreenshot.fire(new TakeScreenshot(screenshotName, metaData, When.BEFORE, event.getTestMethod().getAnnotation(Screenshot.class)));
 
             afterScreenshotTaken.fire(new AfterScreenshotTaken(metaData));
         }
@@ -97,7 +98,7 @@ public class ScreenshooterLifecycleObserver {
 
             beforeScreenshotTaken.fire(new BeforeScreenshotTaken(metaData));
 
-            takeScreenshot.fire(new TakeScreenshot(screenshotName, metaData, when));
+            takeScreenshot.fire(new TakeScreenshot(screenshotName, metaData, when, null));
 
             afterScreenshotTaken.fire(new AfterScreenshotTaken(metaData));
         }

--- a/arquillian-recorder-screenshooter-base/arquillian-recorder-screenshooter-spi/src/main/java/org/arquillian/extension/recorder/screenshooter/event/TakeScreenshot.java
+++ b/arquillian-recorder-screenshooter-base/arquillian-recorder-screenshooter-spi/src/main/java/org/arquillian/extension/recorder/screenshooter/event/TakeScreenshot.java
@@ -38,13 +38,16 @@ public class TakeScreenshot {
 
     private String fileName;
 
-    public TakeScreenshot(String fileName, ScreenshotMetaData metaData, When when) {
+    private org.arquillian.extension.recorder.screenshooter.api.Screenshot annotation;
+
+    public TakeScreenshot(String fileName, ScreenshotMetaData metaData, When when, org.arquillian.extension.recorder.screenshooter.api.Screenshot annotation) {
         Validate.notNull(fileName, "File name is a null object!");
         Validate.notNull(metaData, "Meta data is a null object!");
         Validate.notNull(when, "When is a null object!");
         this.metaData = metaData;
         this.when = when;
         this.fileName = fileName;
+        this.annotation = annotation;
     }
 
     public Screenshot getScreenshot() {
@@ -74,6 +77,10 @@ public class TakeScreenshot {
 
     public String getFileName() {
         return fileName;
+    }
+
+    public org.arquillian.extension.recorder.screenshooter.api.Screenshot getAnnotation() {
+        return annotation;
     }
 
     public void setFileName(String fileName) {


### PR DESCRIPTION
- Graphene screenshooter needs this annotation to decide whether to register onEveryAction interceptor
