### PR TITLE
Removes xuggler API

### DIFF
--- a/arquillian-desktop-video-recorder/pom.xml
+++ b/arquillian-desktop-video-recorder/pom.xml
@@ -44,8 +44,8 @@
         <version.maven.deploy.plugin>2.8.1</version.maven.deploy.plugin>
         <version.maven.compiler.plugin>2.3.2</version.maven.compiler.plugin>
 
-        <maven.compiler.target>1.7</maven.compiler.target>
-        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
     </properties>
     
     <!-- Dependencies -->

--- a/arquillian-desktop-video-recorder/pom.xml
+++ b/arquillian-desktop-video-recorder/pom.xml
@@ -33,18 +33,12 @@
         </developer>
     </developers>
 
-    <repositories>
-        <repository>
-            <id>xuggle repo</id>
-            <url>http://xuggle.googlecode.com/svn/trunk/repo/share/java</url>
-        </repository>
-    </repositories>
-
     <!-- Properties -->
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <jcodec-javase.version>0.1.9</jcodec-javase.version>
+        <thumbnailator.version>0.4.8</thumbnailator.version>
 
         <!-- Other -->
         <version.maven.deploy.plugin>2.8.1</version.maven.deploy.plugin>
@@ -65,6 +59,11 @@
             <groupId>org.jcodec</groupId>
             <artifactId>jcodec-javase</artifactId>
             <version>${jcodec-javase.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.coobird</groupId>
+            <artifactId>thumbnailator</artifactId>
+            <version>${thumbnailator.version}</version>
         </dependency>
     </dependencies>
 

--- a/arquillian-desktop-video-recorder/pom.xml
+++ b/arquillian-desktop-video-recorder/pom.xml
@@ -43,17 +43,16 @@
     <!-- Properties -->
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    
-        <!-- Xuggler -->
-        <xuggler.version>5.4</xuggler.version>
+
+        <jcodec-javase.version>0.1.9</jcodec-javase.version>
 
         <!-- Other -->
         <version.maven.deploy.plugin>2.8.1</version.maven.deploy.plugin>
         <version.maven.compiler.plugin>2.3.2</version.maven.compiler.plugin>
 
-        <maven.compiler.target>1.6</maven.compiler.target>
-        <maven.compiler.source>1.6</maven.compiler.source>
-    </properties>    
+        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.7</maven.compiler.source>
+    </properties>
     
     <!-- Dependencies -->
     <dependencies>
@@ -63,9 +62,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>xuggle</groupId>
-            <artifactId>xuggle-xuggler</artifactId>
-            <version>${xuggler.version}</version>
+            <groupId>org.jcodec</groupId>
+            <artifactId>jcodec-javase</artifactId>
+            <version>${jcodec-javase.version}</version>
         </dependency>
     </dependencies>
 

--- a/arquillian-desktop-video-recorder/src/main/java/org/arquillian/extension/recorder/video/desktop/impl/VideoRecorder.java
+++ b/arquillian-desktop-video-recorder/src/main/java/org/arquillian/extension/recorder/video/desktop/impl/VideoRecorder.java
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import net.coobird.thumbnailator.Thumbnails;
 import org.arquillian.extension.recorder.video.Video;
 import org.arquillian.extension.recorder.video.VideoConfiguration;
 import org.arquillian.extension.recorder.video.VideoType;
@@ -101,7 +102,6 @@ class VideoRecorder {
                     while (running) {
                         BufferedImage bgrScreen = convertToType(getDesktopScreenshot(), BufferedImage.TYPE_3BYTE_BGR);
                         encoder.encodeImage(bgrScreen);
-                        //TODO resize image
                         try {
                             Thread.sleep(500 / frameRate);
                         } catch (InterruptedException ex) {
@@ -115,28 +115,6 @@ class VideoRecorder {
                 } catch (IOException ex) {
                     logger.log(Level.WARNING, "Exception occured during video recording", ex);
                 }
-
-                /*final IMediaWriter writer = ToolFactory.makeWriter(recordedVideo.getAbsolutePath());
-                writer.addVideoStream(0, 0, ICodec.ID.CODEC_ID_H264, screenBounds.width / 2, screenBounds.height / 2);
-
-                long startTime = System.nanoTime();
-
-                timer = new Timer();
-                timer.schedule(new TestTimeoutTask(), TimeUnit.SECONDS.toMillis(configuration.getTestTimeout()));
-
-                while (running) {
-                    BufferedImage bgrScreen = convertToType(getDesktopScreenshot(), BufferedImage.TYPE_3BYTE_BGR);
-                    writer.encodeVideo(0, bgrScreen, System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
-
-                    try {
-                        Thread.sleep(500 / frameRate);
-                    } catch (InterruptedException ex) {
-                        logger.log(Level.WARNING, "Exception occured during video recording", ex);
-                    }
-                    if (!running) {
-                        writer.close();
-                    }
-                }*/
             }
         });
         thread.start();
@@ -187,13 +165,18 @@ class VideoRecorder {
         }
     }
 
-    private BufferedImage convertToType(BufferedImage sourceImage, int targetType) {
+    private BufferedImage convertToType(BufferedImage sourceImage, int targetType) throws IOException {
         BufferedImage image;
         if (sourceImage.getType() == targetType) {
-            image = sourceImage;
+            image = Thumbnails.of(sourceImage)
+                    .size(screenBounds.width, screenBounds.height)
+                    .asBufferedImage();
         } // otherwise create a new image of the target type and draw the new image
         else {
-            image = new BufferedImage(sourceImage.getWidth(), sourceImage.getHeight(), targetType);
+            BufferedImage tmp = Thumbnails.of(sourceImage)
+                    .size(screenBounds.width, screenBounds.height)
+                    .asBufferedImage();
+            image = new BufferedImage(tmp.getWidth(), tmp.getHeight(), targetType);
             image.getGraphics().drawImage(sourceImage, 0, 0, null);
         }
         return image;


### PR DESCRIPTION
Removes xuggler API fixing #23 In this way JCodec is Apache 2 compliant and we will be able to write as screenshooter, a module for drone but for recording videos.

Notice that for resizing images Thumbnails library is used. I have read that it is the fastest library for resizing images, so it should pretty well but it might exist a more direct way to do it. Although that I am not sure why in your original code you did width/2 and height/2 in the resize. I think we don't need resize anymore since screenshot is captured at configured size. 