### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/arquillian-recorder-reporter/arquillian-recorder-reporter-impl/src/main/java/org/arquillian/recorder/reporter/exporter/DefaultExporterRegisterFactory.java
+++ b/arquillian-recorder-reporter/arquillian-recorder-reporter-impl/src/main/java/org/arquillian/recorder/reporter/exporter/DefaultExporterRegisterFactory.java
@@ -29,6 +29,10 @@ public class DefaultExporterRegisterFactory implements ExporterRegisterFactory {
 
     private static class ExporterRegisterHolder {
         public static ExporterRegister lastRegister = new ExporterRegisterImpl();
+
+        private ExporterRegisterHolder() {
+            throw new UnsupportedOperationException("no instantiation");
+        }
     }
 
     private static ExporterRegister getAsSingleton() {

--- a/arquillian-recorder-reporter/arquillian-recorder-reporter-impl/src/main/java/org/arquillian/recorder/reporter/impl/ReporterLifecycleObserver.java
+++ b/arquillian-recorder-reporter/arquillian-recorder-reporter-impl/src/main/java/org/arquillian/recorder/reporter/impl/ReporterLifecycleObserver.java
@@ -279,6 +279,10 @@ public class ReporterLifecycleObserver {
 
     private static final class ReportMessageParser {
 
+        private ReportMessageParser() {
+            throw new UnsupportedOperationException("no instantiation");
+        }
+
         public static String parseTestReportMessage(Method testMethod) {
             return getReportMessage(testMethod.getAnnotations());
         }

--- a/arquillian-recorder-screenshooter-base/arquillian-recorder-screenshooter-impl-base/src/main/java/org/arquillian/extension/recorder/screenshooter/impl/ReflectionUtil.java
+++ b/arquillian-recorder-screenshooter-base/arquillian-recorder-screenshooter-impl-base/src/main/java/org/arquillian/extension/recorder/screenshooter/impl/ReflectionUtil.java
@@ -22,13 +22,17 @@ import java.lang.annotation.Annotation;
  * @author <a href="mailto:asotobu@gmail.com">Alex Soto</a>
  *
  */
-public class ReflectionUtil {
+public final class ReflectionUtil {
 
-public static Class<?> getClassWithAnnotation(final Class<?> source, final Class<? extends Annotation> annotationClass) {
+    private ReflectionUtil() {
+        throw new UnsupportedOperationException("no instantiation");
+    }
+
+    public static Class<?> getClassWithAnnotation(final Class<?> source, final Class<? extends Annotation> annotationClass) {
 
         Class<?> nextSource = source;
         while (nextSource != Object.class) {
-            if(nextSource.isAnnotationPresent(annotationClass)) {
+            if (nextSource.isAnnotationPresent(annotationClass)) {
                 return nextSource;
             } else {
                 nextSource = nextSource.getSuperclass();

--- a/arquillian-recorder-screenshooter-base/arquillian-recorder-screenshooter-impl-base/src/main/java/org/arquillian/extension/recorder/screenshooter/impl/ScreenshotAnnotationScanner.java
+++ b/arquillian-recorder-screenshooter-base/arquillian-recorder-screenshooter-impl-base/src/main/java/org/arquillian/extension/recorder/screenshooter/impl/ScreenshotAnnotationScanner.java
@@ -24,7 +24,11 @@ import org.arquillian.extension.recorder.screenshooter.api.Screenshot;
  * @author <a href="smikloso@redhat.com">Stefan Miklosovic</a>
  *
  */
-public class ScreenshotAnnotationScanner {
+public final class ScreenshotAnnotationScanner {
+
+    private ScreenshotAnnotationScanner() {
+        throw new UnsupportedOperationException("no instantiation");
+    }
 
     /**
      *

--- a/arquillian-recorder/arquillian-recorder-api/src/main/java/org/arquillian/extension/recorder/RecorderFileUtils.java
+++ b/arquillian-recorder/arquillian-recorder-api/src/main/java/org/arquillian/extension/recorder/RecorderFileUtils.java
@@ -24,7 +24,11 @@ import org.jboss.arquillian.core.spi.Validate;
  * @author <a href="smikloso@redhat.com">Stefan Miklosovic</a>
  *
  */
-public class RecorderFileUtils {
+public final class RecorderFileUtils {
+
+    private RecorderFileUtils() {
+        throw new UnsupportedOperationException("no instantiation");
+    }
 
     /**
      *


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat