### PR TITLE
squid:S2325 - private methods that don't access instance data should …

### DIFF
--- a/arquillian-recorder-reporter/arquillian-recorder-reporter-api/src/main/java/org/arquillian/recorder/reporter/LanguageResolver.java
+++ b/arquillian-recorder-reporter/arquillian-recorder-reporter-api/src/main/java/org/arquillian/recorder/reporter/LanguageResolver.java
@@ -104,7 +104,7 @@ class LanguageResolver implements Resolver {
         return supportedLanguages;
     }
 
-    private String parseLanguage(String name) {
+    private static String parseLanguage(String name) {
         String language = name.substring(DEFAULT_TEMPLATE_DIR.length());
         return language.substring(0, language.indexOf("/"));
     }

--- a/arquillian-recorder-reporter/arquillian-recorder-reporter-api/src/main/java/org/arquillian/recorder/reporter/ReporterConfiguration.java
+++ b/arquillian-recorder-reporter/arquillian-recorder-reporter-api/src/main/java/org/arquillian/recorder/reporter/ReporterConfiguration.java
@@ -162,7 +162,7 @@ public class ReporterConfiguration extends Configuration<ReporterConfiguration> 
         return getProperty("title", TITLE);
     }
 
-    private String getFileDefaultFileName() {
+    private static String getFileDefaultFileName() {
         return new StringBuilder()
             .append("arquillian_report")
             .append(".")

--- a/arquillian-recorder-reporter/arquillian-recorder-reporter-impl/src/main/java/org/arquillian/recorder/reporter/exporter/impl/AsciiDocExporter.java
+++ b/arquillian-recorder-reporter/arquillian-recorder-reporter-impl/src/main/java/org/arquillian/recorder/reporter/exporter/impl/AsciiDocExporter.java
@@ -190,7 +190,7 @@ public class AsciiDocExporter implements Exporter {
 
     }
 
-    private String convertDuration(long duration, TimeUnit fromTimeUnit, TimeUnit toTimeUnit) {
+    private static String convertDuration(long duration, TimeUnit fromTimeUnit, TimeUnit toTimeUnit) {
         return Long.toString(toTimeUnit.convert(duration, fromTimeUnit));
     }
 
@@ -656,7 +656,7 @@ public class AsciiDocExporter implements Exporter {
 
     }
 
-    private String getIcon(String iconName, String role) {
+    private static String getIcon(String iconName, String role) {
         return "icon:" + iconName + "[role=\"" + role + "\"]";
     }
 

--- a/arquillian-recorder-reporter/arquillian-recorder-reporter-impl/src/main/java/org/arquillian/recorder/reporter/impl/ReporterLifecycleObserver.java
+++ b/arquillian-recorder-reporter/arquillian-recorder-reporter-impl/src/main/java/org/arquillian/recorder/reporter/impl/ReporterLifecycleObserver.java
@@ -264,7 +264,7 @@ public class ReporterLifecycleObserver {
         return extensionReports;
     }
 
-    private String getStackTrace(Throwable aThrowable) {
+    private static String getStackTrace(Throwable aThrowable) {
         StringBuilder sb = new StringBuilder();
         String newLine = System.getProperty("line.separator");
         sb.append(aThrowable.toString());

--- a/arquillian-recorder-screenshooter-base/arquillian-recorder-screenshooter-api/src/main/java/org/arquillian/extension/recorder/screenshooter/api/BlurLevel.java
+++ b/arquillian-recorder-screenshooter-base/arquillian-recorder-screenshooter-api/src/main/java/org/arquillian/extension/recorder/screenshooter/api/BlurLevel.java
@@ -65,7 +65,7 @@ public enum BlurLevel {
 
     }
 
-    private BufferedImage deepCopy(BufferedImage srcImage) {
+    private static BufferedImage deepCopy(BufferedImage srcImage) {
         ColorModel cm = srcImage.getColorModel();
         boolean isAlphaPremultiplied = cm.isAlphaPremultiplied();
         WritableRaster raster = srcImage.copyData(null);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2325 - "private" methods that don't access instance data should be "static"

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2325

Please let me know if you have any questions.

M-Ezzat