### PR TITLE
Multiple quality improvements - squid:S106, squid:S3052

### DIFF
--- a/arquillian-desktop-video-recorder/src/main/java/org/arquillian/extension/recorder/video/desktop/configuration/DesktopVideoRecorderConfigurator.java
+++ b/arquillian-desktop-video-recorder/src/main/java/org/arquillian/extension/recorder/video/desktop/configuration/DesktopVideoRecorderConfigurator.java
@@ -56,7 +56,7 @@ import org.jboss.arquillian.core.spi.ServiceLoader;
  */
 public class DesktopVideoRecorderConfigurator extends VideoConfigurator {
 
-    private static final Logger logger = Logger.getLogger(DesktopVideoRecorderConfigurator.class.getSimpleName());
+    private static final Logger LOGGER = Logger.getLogger(DesktopVideoRecorderConfigurator.class.getSimpleName());
 
     @Inject
     @ApplicationScoped
@@ -88,9 +88,9 @@ public class DesktopVideoRecorderConfigurator extends VideoConfigurator {
 
         this.configuration.set(configuration);
 
-        if (logger.isLoggable(Level.INFO)) {
-            System.out.println("Configuration of Arquillian Desktop Video Recorder:");
-            System.out.println(this.configuration.get().toString());
+        if (LOGGER.isLoggable(Level.INFO)) {
+            LOGGER.info("Configuration of Arquillian Desktop Video Recorder:");
+            LOGGER.info(this.configuration.get().toString());
         }
 
         // there will be 2 strategies in this list at least - SkippingVideoStrategy and DefaultVideoStrategy

--- a/arquillian-desktop-video-recorder/src/main/java/org/arquillian/extension/recorder/video/desktop/impl/VideoRecorder.java
+++ b/arquillian-desktop-video-recorder/src/main/java/org/arquillian/extension/recorder/video/desktop/impl/VideoRecorder.java
@@ -57,11 +57,11 @@ class VideoRecorder {
 
     private final Dimension screenBounds;
 
-    private volatile boolean running = false;
+    private volatile boolean running;
 
     private Thread thread;
 
-    private File recordedVideo = null;
+    private File recordedVideo;
 
     private Timer timer;
 

--- a/arquillian-recorder-reporter/arquillian-recorder-reporter-impl/src/main/java/org/arquillian/recorder/reporter/configuration/ReporterConfigurator.java
+++ b/arquillian-recorder-reporter/arquillian-recorder-reporter-impl/src/main/java/org/arquillian/recorder/reporter/configuration/ReporterConfigurator.java
@@ -47,7 +47,7 @@ import org.jboss.arquillian.core.api.annotation.Observes;
  */
 public class ReporterConfigurator extends RecorderConfigurator<ReporterConfiguration> {
 
-    private static final Logger logger = Logger.getLogger(ReporterConfigurator.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(ReporterConfigurator.class.getName());
 
     private static final String EXTENSION_NAME = "reporter";
 
@@ -73,9 +73,9 @@ public class ReporterConfigurator extends RecorderConfigurator<ReporterConfigura
 
         this.configuration.set(configuration);
 
-        if (logger.isLoggable(Level.INFO)) {
-            System.out.println("Configuration of Arquillian Reporting extension:");
-            System.out.println(this.configuration.get().toString());
+        if (LOGGER.isLoggable(Level.INFO)) {
+            LOGGER.info("Configuration of Arquillian Reporting extension:");
+            LOGGER.info(this.configuration.get().toString());
         }
 
         extensionConfigured.fire(new ReportingExtensionConfigured());

--- a/arquillian-recorder-reporter/arquillian-recorder-reporter-impl/src/main/java/org/arquillian/recorder/reporter/exporter/impl/AsciiDocExporter.java
+++ b/arquillian-recorder-reporter/arquillian-recorder-reporter-impl/src/main/java/org/arquillian/recorder/reporter/exporter/impl/AsciiDocExporter.java
@@ -84,7 +84,7 @@ public class AsciiDocExporter implements Exporter {
     protected static final String FAIL_STEP = "thumbs-down";
     protected static final String NOT_PERFORMED_STEP = "unlink";
 
-    protected BufferedWriter writer = null;
+    protected BufferedWriter writer;
     protected OutputStream outputStream;
     protected ReporterConfiguration configuration;
 

--- a/arquillian-recorder/arquillian-recorder-api/src/main/java/org/arquillian/extension/recorder/DefaultFileNameBuilder.java
+++ b/arquillian-recorder/arquillian-recorder-api/src/main/java/org/arquillian/extension/recorder/DefaultFileNameBuilder.java
@@ -26,9 +26,9 @@ import java.util.UUID;
  */
 public class DefaultFileNameBuilder extends AbstractFileNameBuilder {
 
-    protected ResourceMetaData metaData = null;
+    protected ResourceMetaData metaData;
 
-    protected When when = null;
+    protected When when;
 
     protected ResourceIdentifier<ResourceType> resourceIdentifier;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S106 - Standard outputs should not be used directly to log anything
squid:S3052 - Fields should not be initialized to default values

You can find more information about the issues here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S106
https://dev.eclipse.org/sonar/coding_rules#q=squid:S3052

Please let me know if you have any questions.

M-Ezzat