### PR TITLE
squid:S1166 - Exception handlers should preserve the original exception

### DIFF
--- a/arquillian-desktop-video-recorder/src/main/java/org/arquillian/extension/recorder/video/desktop/impl/VideoRecorder.java
+++ b/arquillian-desktop-video-recorder/src/main/java/org/arquillian/extension/recorder/video/desktop/impl/VideoRecorder.java
@@ -84,7 +84,7 @@ class VideoRecorder {
         try {
             recordedVideo.createNewFile();
         } catch (IOException ex) {
-            throw new RuntimeException("Unable to create file to which video will be saved: " + recordedVideo.getAbsolutePath());
+            throw new RuntimeException("Unable to create file to which video will be saved: " + recordedVideo.getAbsolutePath(), ex);
         }
 
         running = true;

--- a/arquillian-recorder-reporter/arquillian-recorder-reporter-api/src/main/java/org/arquillian/recorder/reporter/ReporterConfiguration.java
+++ b/arquillian-recorder-reporter/arquillian-recorder-reporter-api/src/main/java/org/arquillian/recorder/reporter/ReporterConfiguration.java
@@ -213,7 +213,8 @@ public class ReporterConfiguration extends Configuration<ReporterConfiguration> 
         } catch (IllegalArgumentException ex) {
             throw new ReporterConfigurationException(
                 "Report frequency you specified in arquillian.xml is not valid. "
-                    + "Supported frequencies are: " + ReportFrequency.getAll());
+                        + "The configured frequency is: " + getReportAfterEvery().toUpperCase() + ". "
+                        + "The supported frequencies are: " + ReportFrequency.getAll(), ex);
         }
 
         // we check language only for html output
@@ -249,7 +250,7 @@ public class ReporterConfiguration extends Configuration<ReporterConfiguration> 
             }
         } catch (SecurityException ex) {
             throw new ReporterConfigurationException(
-                "You are not permitted to operate on specified resource: " + getRootDir().getAbsolutePath() + "'.");
+                "You are not permitted to operate on specified resource: " + getRootDir().getAbsolutePath() + "'.", ex);
         }
 
         setFileName(getProperty("report", report));

--- a/arquillian-recorder-screenshooter-base/arquillian-recorder-screenshooter-api/src/main/java/org/arquillian/extension/recorder/screenshooter/ScreenshooterConfiguration.java
+++ b/arquillian-recorder-screenshooter-base/arquillian-recorder-screenshooter-api/src/main/java/org/arquillian/extension/recorder/screenshooter/ScreenshooterConfiguration.java
@@ -112,8 +112,9 @@ public class ScreenshooterConfiguration extends Configuration<ScreenshooterConfi
             ScreenshotType.valueOf(ScreenshotType.class, getScreenshotType());
         } catch (IllegalArgumentException ex) {
             throw new ScreenshooterConfigurationException(
-                "Screenshot type you specified in arquillian.xml is not valid screenshot type."
-                    + "Supported screenshot types are: " + ScreenshotType.getAll());
+                "Screenshot type you specified in arquillian.xml is not valid screenshot type. "
+                        + "The configured screenshot type is: " + getScreenshotType() + ". "
+                        + "The supported screenshot types are: " + ScreenshotType.getAll(), ex);
         }
 
         final String report = reporterConfiguration.getReport().toLowerCase();
@@ -144,7 +145,7 @@ public class ScreenshooterConfiguration extends Configuration<ScreenshooterConfi
             }
         } catch (SecurityException ex) {
             throw new ScreenshooterConfigurationException(
-                "You are not permitted to operate on specified resource: " + getRootDir().getAbsolutePath() + "'.");
+                "You are not permitted to operate on specified resource: " + getRootDir().getAbsolutePath() + "'.", ex);
         }
 
     }

--- a/arquillian-recorder-video-base/arquillian-recorder-video-api/src/main/java/org/arquillian/extension/recorder/video/VideoConfiguration.java
+++ b/arquillian-recorder-video-base/arquillian-recorder-video-api/src/main/java/org/arquillian/extension/recorder/video/VideoConfiguration.java
@@ -155,8 +155,9 @@ public class VideoConfiguration extends Configuration<VideoConfiguration> {
             VideoType.valueOf(VideoType.class, getVideoType());
         } catch (IllegalArgumentException ex) {
             throw new VideoConfigurationException(
-                "Video type you specified in arquillian.xml is not valid video type."
-                    + "Supported video types are: " + VideoType.getAll());
+                "Video type you specified in arquillian.xml is not valid video type. "
+                        + "The configured video type is: " + getVideoType() + ". "
+                        + "The supported video types are: " + VideoType.getAll());
         }
 
         final String report = reporterConfiguration.getReport().toLowerCase();
@@ -186,7 +187,7 @@ public class VideoConfiguration extends Configuration<VideoConfiguration> {
             }
         } catch (SecurityException ex) {
             throw new VideoConfigurationException(
-                "You are not permitted to operate on specified resource: " + getRootDir().getAbsolutePath() + "'.");
+                "You are not permitted to operate on specified resource: " + getRootDir().getAbsolutePath() + "'.", ex);
         }
 
         try {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1166 - Exception handlers should preserve the original exception

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1166

Please let me know if you have any questions.

M-Ezzat