### PR TITLE
squid:HiddenFieldCheck - Local variables should not shadow class fields

### DIFF
--- a/arquillian-desktop-video-recorder/src/main/java/org/arquillian/extension/recorder/video/desktop/configuration/DesktopVideoRecorderConfigurator.java
+++ b/arquillian-desktop-video-recorder/src/main/java/org/arquillian/extension/recorder/video/desktop/configuration/DesktopVideoRecorderConfigurator.java
@@ -76,17 +76,17 @@ public class DesktopVideoRecorderConfigurator extends VideoConfigurator {
     private Instance<VideoRecorderEnvironmentCleaner> cleaner;
 
     public void afterVideoExtensionConfigured(@Observes VideoExtensionConfigured event, ArquillianDescriptor descriptor) {
-        VideoConfiguration configuration = new DesktopVideoConfiguration(reporterConfiguration.get());
+        VideoConfiguration configurationLocal = new DesktopVideoConfiguration(reporterConfiguration.get());
 
         for (ExtensionDef extension : descriptor.getExtensions()) {
             if (extension.getExtensionName().equals(EXTENSION_NAME)) {
-                configuration.setConfiguration(extension.getExtensionProperties());
-                configuration.validate();
+                configurationLocal.setConfiguration(extension.getExtensionProperties());
+                configurationLocal.validate();
                 break;
             }
         }
 
-        this.configuration.set(configuration);
+        this.configuration.set(configurationLocal);
 
         if (LOGGER.isLoggable(Level.INFO)) {
             LOGGER.info("Configuration of Arquillian Desktop Video Recorder:");

--- a/arquillian-desktop-video-recorder/src/main/java/org/arquillian/extension/recorder/video/desktop/impl/DesktopVideoRecorderCreator.java
+++ b/arquillian-desktop-video-recorder/src/main/java/org/arquillian/extension/recorder/video/desktop/impl/DesktopVideoRecorderCreator.java
@@ -59,10 +59,10 @@ public class DesktopVideoRecorderCreator {
             this.takenResourceRegister.set(new TakenResourceRegister());
         }
 
-        Recorder recorder = new DesktopVideoRecorder(takenResourceRegister.get());
-        recorder.init((DesktopVideoConfiguration) configuration.get());
+        Recorder recorderLocal = new DesktopVideoRecorder(takenResourceRegister.get());
+        recorderLocal.init((DesktopVideoConfiguration) configuration.get());
 
-        this.recorder.set(recorder);
+        this.recorder.set(recorderLocal);
     }
 
 }

--- a/arquillian-recorder-reporter/arquillian-recorder-reporter-api/src/main/java/org/arquillian/recorder/reporter/LanguageResolver.java
+++ b/arquillian-recorder-reporter/arquillian-recorder-reporter-api/src/main/java/org/arquillian/recorder/reporter/LanguageResolver.java
@@ -79,7 +79,7 @@ class LanguageResolver implements Resolver {
      * @return
      */
     protected List<String> resolveSupportedLanguages() {
-        List<String> supportedLanguages = new ArrayList<String>();
+        List<String> supportedLanguagesLocal = new ArrayList<String>();
         final File jarFile = new File(getClass().getProtectionDomain().getCodeSource().getLocation().getPath());
 
         if (jarFile.isFile()) { // Run with JAR file
@@ -92,7 +92,7 @@ class LanguageResolver implements Resolver {
                     if ((entry.getName().startsWith(DEFAULT_TEMPLATE_DIR)
                         || entry.getName().startsWith(DEFAULT_TEMPLATE_BASE_DIR))
                         && entry.getName().endsWith(DEFAULT_TEMPLATE_EXTENSION)) {
-                        supportedLanguages.add(parseLanguage(entry.getName()));
+                        supportedLanguagesLocal.add(parseLanguage(entry.getName()));
                     }
                 }
                 jar.close();
@@ -101,7 +101,7 @@ class LanguageResolver implements Resolver {
             }
         }
 
-        return supportedLanguages;
+        return supportedLanguagesLocal;
     }
 
     private static String parseLanguage(String name) {

--- a/arquillian-recorder-reporter/arquillian-recorder-reporter-impl/src/main/java/org/arquillian/recorder/reporter/ReporterExtensionInitializer.java
+++ b/arquillian-recorder-reporter/arquillian-recorder-reporter-impl/src/main/java/org/arquillian/recorder/reporter/ReporterExtensionInitializer.java
@@ -90,9 +90,9 @@ public class ReporterExtensionInitializer {
 
         // produce default reporter
 
-        Reporter reporter = serviceLoader.get().onlyOne(Reporter.class, ReporterImpl.class);
-        reporter.setConfiguration(configuration.get());
-        this.reporter.set(reporter);
+        Reporter reporterLocal = serviceLoader.get().onlyOne(Reporter.class, ReporterImpl.class);
+        reporterLocal.setConfiguration(configuration.get());
+        this.reporter.set(reporterLocal);
 
         // produce default exporter
 

--- a/arquillian-recorder-reporter/arquillian-recorder-reporter-impl/src/main/java/org/arquillian/recorder/reporter/configuration/ReporterConfigurator.java
+++ b/arquillian-recorder-reporter/arquillian-recorder-reporter-impl/src/main/java/org/arquillian/recorder/reporter/configuration/ReporterConfigurator.java
@@ -60,18 +60,18 @@ public class ReporterConfigurator extends RecorderConfigurator<ReporterConfigura
 
     public void configureExtension(@Observes ArquillianDescriptor descriptor) {
 
-        ReporterConfiguration configuration = new ReporterConfiguration();
+        ReporterConfiguration configurationLocal = new ReporterConfiguration();
 
         for (ExtensionDef extension : descriptor.getExtensions()) {
             if (extension.getExtensionName().equals(EXTENSION_NAME)) {
-                configuration.setConfiguration(extension.getExtensionProperties());
+                configurationLocal.setConfiguration(extension.getExtensionProperties());
                 break;
             }
         }
 
-        configuration.validate();
+        configurationLocal.validate();
 
-        this.configuration.set(configuration);
+        this.configuration.set(configurationLocal);
 
         if (LOGGER.isLoggable(Level.INFO)) {
             LOGGER.info("Configuration of Arquillian Reporting extension:");

--- a/arquillian-recorder-screenshooter-base/arquillian-recorder-screenshooter-impl-base/src/main/java/org/arquillian/extension/recorder/screenshooter/impl/ScreenshooterExtensionInitializer.java
+++ b/arquillian-recorder-screenshooter-base/arquillian-recorder-screenshooter-impl-base/src/main/java/org/arquillian/extension/recorder/screenshooter/impl/ScreenshooterExtensionInitializer.java
@@ -67,10 +67,10 @@ public class ScreenshooterExtensionInitializer {
         recorderStrategyRegister.set(new RecorderStrategyRegister());
         recorderStrategyRegister.get().addAll(recorderStrategies);
 
-        ScreenshooterEnvironmentCleaner cleaner = serviceLoader.get()
+        ScreenshooterEnvironmentCleaner cleanerLocal = serviceLoader.get()
             .onlyOne(ScreenshooterEnvironmentCleaner.class, DefaultScreenshooterEnvironmentCleaner.class);
 
-        this.cleaner.set(cleaner);
+        this.cleaner.set(cleanerLocal);
 
         try {
             this.cleaner.get().clean(configuration.get());

--- a/arquillian-recorder-screenshooter-base/arquillian-recorder-screenshooter-impl-base/src/main/java/org/arquillian/extension/recorder/screenshooter/impl/ScreenshooterProvider.java
+++ b/arquillian-recorder-screenshooter-base/arquillian-recorder-screenshooter-impl-base/src/main/java/org/arquillian/extension/recorder/screenshooter/impl/ScreenshooterProvider.java
@@ -40,13 +40,13 @@ public class ScreenshooterProvider implements ResourceProvider {
 
     @Override
     public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
-        Screenshooter screenshooter = this.screenshooter.get();
+        Screenshooter screenshooterLocal = this.screenshooter.get();
 
-        if (screenshooter == null) {
+        if (screenshooterLocal == null) {
             throw new IllegalStateException("Unable to inject screenshooter into test.");
         }
 
-        return screenshooter;
+        return screenshooterLocal;
     }
 
 }

--- a/arquillian-recorder-video-base/arquillian-recorder-video-impl-base/src/main/java/org/arquillian/extension/recorder/video/impl/RecorderProvider.java
+++ b/arquillian-recorder-video-base/arquillian-recorder-video-impl-base/src/main/java/org/arquillian/extension/recorder/video/impl/RecorderProvider.java
@@ -44,24 +44,24 @@ public class RecorderProvider implements ResourceProvider {
 
     @Override
     public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
-        Recorder recorder = this.recorder.get();
+        Recorder recorderLocal = this.recorder.get();
 
-        VideoConfiguration configuration = this.configuration.get();
+        VideoConfiguration configurationLocal = this.configuration.get();
 
-        if (configuration == null || recorder == null) {
+        if (configurationLocal == null || recorderLocal == null) {
             throw new IllegalStateException("Unable to inject recorder into test. Be sure there is some Video Recorder "
                 + "implementation on the class path.");
         }
 
-        if (configuration.getStartBeforeClass() || configuration.getStartBeforeSuite()
-            || configuration.getStartBeforeTest() || configuration.getTakeOnlyOnFail()) {
+        if (configurationLocal.getStartBeforeClass() || configurationLocal.getStartBeforeSuite()
+            || configurationLocal.getStartBeforeTest() || configurationLocal.getTakeOnlyOnFail()) {
             throw new IllegalStateException("It is not possible to inject video recorder into test "
                 + "when you have specified that you want to take videos automatically via configuration "
                 + "where you set one of start* properties to true or takeOnlyOnFail to true. In order "
                 + "to use recorder manually in test class, you have to set all mentioned above to false.");
         }
 
-        return recorder;
+        return recorderLocal;
     }
 
 }

--- a/arquillian-recorder-video-base/arquillian-recorder-video-impl-base/src/main/java/org/arquillian/extension/recorder/video/impl/VideoRecorderExtensionInitializer.java
+++ b/arquillian-recorder-video-base/arquillian-recorder-video-impl-base/src/main/java/org/arquillian/extension/recorder/video/impl/VideoRecorderExtensionInitializer.java
@@ -62,13 +62,13 @@ public class VideoRecorderExtensionInitializer {
 
     public void afterReportingExtensionConfigured(@Observes ReportingExtensionConfigured event) {
 
-        VideoStrategy strategy = new SkippingVideoStrategy();
+        VideoStrategy strategyLocal = new SkippingVideoStrategy();
 
-        VideoRecorderEnvironmentCleaner cleaner = serviceLoader.get().onlyOne(VideoRecorderEnvironmentCleaner.class,
+        VideoRecorderEnvironmentCleaner cleanerLocal = serviceLoader.get().onlyOne(VideoRecorderEnvironmentCleaner.class,
             DefaultVideoRecorderEnvironmentCleaner.class);
 
-        this.strategy.set(strategy);
-        this.cleaner.set(cleaner);
+        this.strategy.set(strategyLocal);
+        this.cleaner.set(cleanerLocal);
 
         extensionConfiguredEvent.fire(new VideoExtensionConfigured());
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:HiddenFieldCheck - Local variables should not shadow class fields

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:HiddenFieldCheck

Please let me know if you have any questions.

M-Ezzat