### PR TITLE
squid:S2275 - Printf-style format strings should not lead to unexpect…

### DIFF
--- a/arquillian-desktop-video-recorder/src/main/java/org/arquillian/extension/recorder/video/desktop/configuration/DesktopVideoConfiguration.java
+++ b/arquillian-desktop-video-recorder/src/main/java/org/arquillian/extension/recorder/video/desktop/configuration/DesktopVideoConfiguration.java
@@ -95,7 +95,7 @@ public class DesktopVideoConfiguration extends VideoConfiguration {
         String parent = super.toString();
         StringBuilder sb = new StringBuilder();
         sb.append(parent);
-        sb.append(String.format("%-40s %s\n", "frameRate", getFrameRate()));
+        sb.append(String.format("%-40s %s%n", "frameRate", getFrameRate()));
         return sb.toString();
     }
 }

--- a/arquillian-recorder-screenshooter-base/arquillian-recorder-screenshooter-api/src/main/java/org/arquillian/extension/recorder/screenshooter/ScreenshooterConfiguration.java
+++ b/arquillian-recorder-screenshooter-base/arquillian-recorder-screenshooter-api/src/main/java/org/arquillian/extension/recorder/screenshooter/ScreenshooterConfiguration.java
@@ -98,11 +98,11 @@ public class ScreenshooterConfiguration extends Configuration<ScreenshooterConfi
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        sb.append(String.format("%-40s %s\n", "rootDir", getRootDir()));
-        sb.append(String.format("%-40s %s\n", "screenshotType", getScreenshotType()));
-        sb.append(String.format("%-40s %s\n", "takeBeforeTest", getTakeBeforeTest()));
-        sb.append(String.format("%-40s %s\n", "takeAfterTest", getTakeAfterTest()));
-        sb.append(String.format("%-40s %s\n", "takeWhenTestFailed", getTakeWhenTestFailed()));
+        sb.append(String.format("%-40s %s%n", "rootDir", getRootDir()));
+        sb.append(String.format("%-40s %s%n", "screenshotType", getScreenshotType()));
+        sb.append(String.format("%-40s %s%n", "takeBeforeTest", getTakeBeforeTest()));
+        sb.append(String.format("%-40s %s%n", "takeAfterTest", getTakeAfterTest()));
+        sb.append(String.format("%-40s %s%n", "takeWhenTestFailed", getTakeWhenTestFailed()));
         return sb.toString();
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2275 - Printf-style format strings should not lead to unexpected behavior at runtime

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2275

Please let me know if you have any questions.

M-Ezzat