### PR TITLE
squid:S1871 - Two branches in the same conditional structure should n…

### DIFF
--- a/arquillian-recorder-reporter/arquillian-recorder-reporter-impl/src/main/java/org/arquillian/recorder/reporter/impl/ReporterLifecycleObserver.java
+++ b/arquillian-recorder-reporter/arquillian-recorder-reporter-impl/src/main/java/org/arquillian/recorder/reporter/impl/ReporterLifecycleObserver.java
@@ -244,9 +244,8 @@ public class ReporterLifecycleObserver {
     }
 
     private boolean shouldReport(org.jboss.arquillian.core.spi.event.Event event, String frequency) {
-        if (event instanceof AfterClass && ReportFrequency.CLASS.toString().equals(frequency)) {
-            return true;
-        } else if (event instanceof After && ReportFrequency.METHOD.toString().equals(frequency)) {
+        if (event instanceof AfterClass && ReportFrequency.CLASS.toString().equals(frequency)
+                || (event instanceof After && ReportFrequency.METHOD.toString().equals(frequency)) ) {
             return true;
         }
         return false;

--- a/arquillian-recorder-video-base/arquillian-recorder-video-impl-base/src/main/java/org/arquillian/extension/recorder/video/impl/DefaultVideoStrategy.java
+++ b/arquillian-recorder-video-base/arquillian-recorder-video-impl-base/src/main/java/org/arquillian/extension/recorder/video/impl/DefaultVideoStrategy.java
@@ -47,12 +47,11 @@ public class DefaultVideoStrategy implements VideoStrategy {
     public boolean isTakingAction(Event event, TestResult result) {
         if (event instanceof AfterTestLifecycleEvent && !(event instanceof After)) {
             switch (result.getStatus()) {
-                case SKIPPED:
-                    return false;
                 case FAILED:
                     return configuration.getTakeOnlyOnFail();
                 case PASSED:
                     return configuration.getStartBeforeTest() || configuration.getTakeOnlyOnFail();
+                case SKIPPED:
                 default:
                     return false;
             }
@@ -62,17 +61,15 @@ public class DefaultVideoStrategy implements VideoStrategy {
 
     @Override
     public boolean isTakingAction(Event event) {
-        if (event instanceof BeforeSuite) {
+        if (event instanceof BeforeSuite
+                || event instanceof AfterSuite) {
             return configuration.getStartBeforeSuite();
-        } else if (event instanceof BeforeClass) {
+        } else if (event instanceof BeforeClass
+                || event instanceof AfterClass) {
             return configuration.getStartBeforeClass();
         } else if (event instanceof Before) {
             return configuration.getStartBeforeTest()
                 || configuration.getTakeOnlyOnFail();
-        } else if (event instanceof AfterSuite) {
-            return configuration.getStartBeforeSuite();
-        } else if (event instanceof AfterClass) {
-            return configuration.getStartBeforeClass();
         }
 
         return false;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1871 - Two branches in the same conditional structure should not have exactly the same implementation

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1871

Please let me know if you have any questions.

M-Ezzat