### PR TITLE
Cleanup - squid:S1312 - Loggers should be "private static final" and …

### DIFF
--- a/arquillian-desktop-video-recorder/src/main/java/org/arquillian/extension/recorder/video/desktop/configuration/DesktopVideoConfiguration.java
+++ b/arquillian-desktop-video-recorder/src/main/java/org/arquillian/extension/recorder/video/desktop/configuration/DesktopVideoConfiguration.java
@@ -29,7 +29,7 @@ import org.arquillian.recorder.reporter.ReporterConfiguration;
  */
 public class DesktopVideoConfiguration extends VideoConfiguration {
 
-    private static Logger logger = Logger.getLogger(DesktopVideoConfiguration.class.getSimpleName());
+    private static final Logger LOGGER = Logger.getLogger(DesktopVideoConfiguration.class.getSimpleName());
 
     private static final String FRAME_RATE = "20"; // fps
 
@@ -61,19 +61,19 @@ public class DesktopVideoConfiguration extends VideoConfiguration {
         if ((getStartBeforeClass() || getStartBeforeSuite())
             && getStartBeforeTest()) {
             setProperty("startBeforeTest", "false");
-            logger.log(Level.INFO, "You have set both startBeforeTest and startBeforeSuite or startBeforeClass to true - "
+            LOGGER.log(Level.INFO, "You have set both startBeforeTest and startBeforeSuite or startBeforeClass to true - "
                 + "startBeforeTest was set to false.");
         }
 
         if (getStartBeforeSuite() && getStartBeforeClass()) {
-            logger.log(Level.INFO, "You have set startBeforeSuite and startBeforeClass both to true. You can not set them "
+            LOGGER.log(Level.INFO, "You have set startBeforeSuite and startBeforeClass both to true. You can not set them "
                 + "simultaneously to true - startBeforeSuite has precedence so startBeforeClass was set to true.");
             setProperty("startBeforeClass", "false");
         }
 
         if (getTakeOnlyOnFail() && getStartBeforeTest()) {
             setProperty("startBeforeTest", "false");
-            logger.log(Level.INFO, "You have set takeOnlyOnFail to true as well as startBeforeTest to true. You can not set "
+            LOGGER.log(Level.INFO, "You have set takeOnlyOnFail to true as well as startBeforeTest to true. You can not set "
                 + "both to true - startBeforeTest was set to false. Videos of all tests will be recorded automatically "
                 + "and some video of test will be preserved only if test fails.");
         }
@@ -84,7 +84,7 @@ public class DesktopVideoConfiguration extends VideoConfiguration {
             setProperty("startBeforeSuite", "false");
             setProperty("startBeforeTest", "false");
 
-            logger.log(Level.INFO, "You have set one of startBeforeClass, startBeforeSuite or startBeforeTest in connection "
+            LOGGER.log(Level.INFO, "You have set one of startBeforeClass, startBeforeSuite or startBeforeTest in connection "
                 + "with takeOnlyOnFail. All start* properties were set to false so every @Test will be recorded and "
                 + "preserved only in case it has failed");
         }

--- a/arquillian-desktop-video-recorder/src/main/java/org/arquillian/extension/recorder/video/desktop/impl/VideoRecorder.java
+++ b/arquillian-desktop-video-recorder/src/main/java/org/arquillian/extension/recorder/video/desktop/impl/VideoRecorder.java
@@ -45,7 +45,7 @@ import org.jcodec.api.awt.SequenceEncoder;
  */
 class VideoRecorder {
 
-    private static final Logger logger = Logger.getLogger(VideoRecorder.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(VideoRecorder.class.getName());
 
     public static final int DEFAULT_FRAMERATE = 20;
 
@@ -105,7 +105,7 @@ class VideoRecorder {
                         try {
                             Thread.sleep(500 / frameRate);
                         } catch (InterruptedException ex) {
-                            logger.log(Level.WARNING, "Exception occured during video recording", ex);
+                            LOGGER.log(Level.WARNING, "Exception occured during video recording", ex);
                         }
                         if (!running) {
                             encoder.finish();
@@ -113,7 +113,7 @@ class VideoRecorder {
                     }
 
                 } catch (IOException ex) {
-                    logger.log(Level.WARNING, "Exception occured during video recording", ex);
+                    LOGGER.log(Level.WARNING, "Exception occured during video recording", ex);
                 }
             }
         });
@@ -189,7 +189,7 @@ class VideoRecorder {
             Rectangle captureSize = new Rectangle(screenBounds);
             return robot.createScreenCapture(captureSize);
         } catch (AWTException e) {
-            logger.log(Level.WARNING, "Exception occured while taking screenshot for video record", e);
+            LOGGER.log(Level.WARNING, "Exception occured while taking screenshot for video record", e);
             return null;
         }
     }

--- a/arquillian-recorder-reporter/arquillian-recorder-reporter-api/src/main/java/org/arquillian/recorder/reporter/ReporterConfiguration.java
+++ b/arquillian-recorder-reporter/arquillian-recorder-reporter-api/src/main/java/org/arquillian/recorder/reporter/ReporterConfiguration.java
@@ -29,7 +29,7 @@ import org.arquillian.extension.recorder.Configuration;
  */
 public class ReporterConfiguration extends Configuration<ReporterConfiguration> {
 
-    private static final Logger logger = Logger.getLogger(ReporterConfiguration.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(ReporterConfiguration.class.getName());
 
     public static final String DEFAULT_TYPE = "xml";
 
@@ -173,7 +173,7 @@ public class ReporterConfiguration extends Configuration<ReporterConfiguration> 
     @Override
     public void validate() throws ReporterConfigurationException {
         if (report.isEmpty()) {
-            logger.info("Report type can not be empty string! Choosing default type \"xml\"");
+            LOGGER.info("Report type can not be empty string! Choosing default type \"xml\"");
             report = DEFAULT_TYPE;
         }
 
@@ -224,7 +224,7 @@ public class ReporterConfiguration extends Configuration<ReporterConfiguration> 
             List<String> supportedLanguages = languageResolver.getSupportedLanguages();
 
             if (!languageResolver.isLanguageSupported(getLanguage())) {
-                logger.log(Level.INFO, "Language you set ({0}) for HTML report is not supported. It will default to "
+                LOGGER.log(Level.INFO, "Language you set ({0}) for HTML report is not supported. It will default to "
                     + "\"{1}\". When you are executing this from IDE, put reporter api jar to build path among external "
                     + "jars in order to scan it.",
                     new Object[] { getLanguage(), DEFAULT_LANGUAGE, supportedLanguages });

--- a/arquillian-recorder-reporter/arquillian-recorder-reporter-api/src/main/java/org/arquillian/recorder/reporter/model/ReportConfiguration.java
+++ b/arquillian-recorder-reporter/arquillian-recorder-reporter-api/src/main/java/org/arquillian/recorder/reporter/model/ReportConfiguration.java
@@ -34,7 +34,7 @@ import org.arquillian.recorder.reporter.ReportEntry;
 @XmlRootElement(name = "reportConfiguration")
 public class ReportConfiguration implements ReportEntry {
 
-    private static final Logger logger = Logger.getLogger(ReportConfiguration.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(ReportConfiguration.class.getName());
 
     private static final int MAX_HEIGHT_IN_PERCENT = 100;
 
@@ -64,7 +64,7 @@ public class ReportConfiguration implements ReportEntry {
                 this.maxImageWidth = maxImageWidth;
             }
         } catch (NumberFormatException ex) {
-            logger.info(String.format("You are trying to parse '%s' as a number for maxImageWidth.", maxImageWidth));
+            LOGGER.info(String.format("You are trying to parse '%s' as a number for maxImageWidth.", maxImageWidth));
         }
     }
 
@@ -80,7 +80,7 @@ public class ReportConfiguration implements ReportEntry {
                 this.imageWidth = imageWidth;
             }
         } catch (NumberFormatException ex) {
-            logger.info(String.format("You are trying to parse '%s' as a number for imageWidth.", imageWidth));
+            LOGGER.info(String.format("You are trying to parse '%s' as a number for imageWidth.", imageWidth));
         }
     }
 
@@ -96,7 +96,7 @@ public class ReportConfiguration implements ReportEntry {
                 this.imageHeight = imageHeight;
             }
         } catch (NumberFormatException ex) {
-            logger.info(String.format("You are trying to parse '%s' as a number for imageHeight.", imageHeight));
+            LOGGER.info(String.format("You are trying to parse '%s' as a number for imageHeight.", imageHeight));
         }
     }
 

--- a/arquillian-recorder/arquillian-recorder-api/src/main/java/org/arquillian/extension/recorder/RecorderFileUtils.java
+++ b/arquillian-recorder/arquillian-recorder-api/src/main/java/org/arquillian/extension/recorder/RecorderFileUtils.java
@@ -26,7 +26,7 @@ import org.jboss.arquillian.core.spi.Validate;
  */
 public final class RecorderFileUtils {
 
-    private static final Logger logger = Logger.getLogger(RecorderFileUtils.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(RecorderFileUtils.class.getName());
 
     private RecorderFileUtils() {
         throw new UnsupportedOperationException("no instantiation");
@@ -60,7 +60,7 @@ public final class RecorderFileUtils {
                     throw new IllegalStateException("Unable to create directory " + file.getAbsolutePath());
                 }
             } catch (SecurityException ex) {
-                logger.warning("Unable to create directory due to security exception: " + ex.getMessage());
+                LOGGER.warning("Unable to create directory due to security exception: " + ex.getMessage());
             }
         }
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1312 - Loggers should be "private static final" and should share a naming convention

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1312

Please let me know if you have any questions.

M-Ezzat