### PR TITLE
Remove skip of maven-deploy-plugin in pom.xml

### DIFF
--- a/arquillian-desktop-video-recorder/pom.xml
+++ b/arquillian-desktop-video-recorder/pom.xml
@@ -79,14 +79,6 @@
                     <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <version>${version.maven.deploy.plugin}</version>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Issue 23: After migrating to the JCodec library, the license problem
that prevented pushing arquillian-desktop-video-recorder to Maven
central is no longer present. Remove the maven-deploy-plugin element from the pom.xml file.

https://github.com/arquillian/arquillian-recorder/issues/23#issuecomment
-191700616

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/arquillian/arquillian-recorder/50)
<!-- Reviewable:end -->
