### PR TITLE
Updates to render logs as links in reports.

### DIFF
--- a/arquillian-recorder-reporter/arquillian-recorder-reporter-api/src/main/java/org/arquillian/recorder/reporter/model/entry/GroupEntry.java
+++ b/arquillian-recorder-reporter/arquillian-recorder-reporter-api/src/main/java/org/arquillian/recorder/reporter/model/entry/GroupEntry.java
@@ -51,8 +51,10 @@ public class GroupEntry extends PropertyEntry {
         @XmlElement(name = "table", type = TableEntry.class),
         @XmlElement(name = "group", type = GroupEntry.class),
         @XmlElement(name = "screenshot", type = ScreenshotEntry.class),
-        @XmlElement(name = "video", type = VideoEntry.class)
+        @XmlElement(name = "video", type = VideoEntry.class),
+        @XmlElement(name = "file", type = FileEntry.class)
     })
+
     private final List<PropertyEntry> propertyEntries = new ArrayList<PropertyEntry>();
 
     public GroupEntry() {

--- a/arquillian-recorder-reporter/arquillian-recorder-reporter-api/src/main/resources/arquillian_reporter_templates/en/arquillian_reporter_template.xsl
+++ b/arquillian-recorder-reporter/arquillian-recorder-reporter-api/src/main/resources/arquillian_reporter_templates/en/arquillian_reporter_template.xsl
@@ -71,8 +71,15 @@
         <xsl:apply-templates select="table"/>
         <xsl:apply-templates select="screenshot"/>
         <xsl:apply-templates select="video"/>
+        <xsl:apply-templates select="file"/>
         <xsl:apply-templates select="group"/>
     </div>
+</xsl:template>
+
+<xsl:template match="file">
+   <div class="file">
+        <a href="{@path}"><xsl:value-of select="@path"/></a>
+   </div>
 </xsl:template>
 
 <xsl:template match="extension">
@@ -256,13 +263,11 @@
             <xsl:for-each select="/report/property">
               <tr><td><xsl:value-of select="key"/></td><td><xsl:value-of select="value"/></td></tr>
             </xsl:for-each>
-            <xsl:for-each select="/report/file">
-              <tr><td colspan="2"><xsl:value-of select="@path"/></td></tr>
-            </xsl:for-each>
           </tbody>
         </table>
 
         <xsl:apply-templates select="/report/table"/>
+        <xsl:apply-templates select="/report/file"/>
         <xsl:apply-templates select="/report/group"/>
       </div>
 
@@ -296,13 +301,11 @@
               <xsl:for-each select="property">
                 <tr><td><xsl:value-of select="key"/></td><td><xsl:value-of select="value"/></td></tr>
               </xsl:for-each>
-              <xsl:for-each select="file">
-                <tr><td colspan="2"><xsl:value-of select="@path"/></td></tr>
-              </xsl:for-each>
             </tbody>
           </table>
           <xsl:apply-templates select="text"/>
           <xsl:apply-templates select="table"/>
+          <xsl:apply-templates select="file"/>
           <xsl:apply-templates select="group"/>
         </div>
 
@@ -353,13 +356,11 @@
                   <xsl:for-each select="property">
                     <tr><td><xsl:value-of select="key"/></td><td><xsl:value-of select="value"/></td></tr>
                   </xsl:for-each>
-                  <xsl:for-each select="file">
-                    <tr><td colspan="2"><xsl:value-of select="@path"/></td></tr>
-                  </xsl:for-each>
                 </tbody>
               </table>
               <xsl:apply-templates select="text"/>
               <xsl:apply-templates select="table"/>
+              <xsl:apply-templates select="file"/>
               <xsl:apply-templates select="group"/>
             </div>
 
@@ -391,14 +392,12 @@
                       <xsl:for-each select="property">
                         <tr><td><xsl:value-of select="key"/></td><td><xsl:value-of select="value"/></td></tr>
                       </xsl:for-each>
-                      <xsl:for-each select="file">
-                        <tr><td colspan="2"><xsl:value-of select="@path"/></td></tr>
-                      </xsl:for-each>
                     </tbody>
                   </table>
                   <xsl:apply-templates select="text"/>
                   <xsl:apply-templates select="video"/>
                   <xsl:apply-templates select="table"/>
+                  <xsl:apply-templates select="file"/>
                   <xsl:apply-templates select="group"/>
                 </div>
 


### PR DESCRIPTION
#### Short description of what this resolves:

HTML reports generated have the location of the log files rendered as standard text. The logs can be made accessible within the report by rendering the log references as links rather than as text. 
#### Changes proposed in this pull request:
- Update XSL template to render logs as links instead of standard text.
- Group the logs (file entries) with title for better readability. 

**Fixes**: #55 
#### Screenshots:
##### Screenshot With Location rendered as standard Text

![screenshot before change](https://cloud.githubusercontent.com/assets/8680543/19802838/24a62b2a-9d23-11e6-92e5-4b43ef317398.png)
##### Screenshot With Location rendered as Link

![screenshot after change](https://cloud.githubusercontent.com/assets/8680543/19802833/2288062e-9d23-11e6-9cbc-f24d16fc0b05.png)
