### PR TITLE
Arquillian recorder issue#60

### DIFF
--- a/arquillian-desktop-video-recorder/src/main/java/org/arquillian/extension/recorder/video/desktop/configuration/DesktopVideoRecorderConfigurator.java
+++ b/arquillian-desktop-video-recorder/src/main/java/org/arquillian/extension/recorder/video/desktop/configuration/DesktopVideoRecorderConfigurator.java
@@ -81,11 +81,11 @@ public class DesktopVideoRecorderConfigurator extends VideoConfigurator {
         for (ExtensionDef extension : descriptor.getExtensions()) {
             if (extension.getExtensionName().equals(EXTENSION_NAME)) {
                 configuration.setConfiguration(extension.getExtensionProperties());
-                configuration.validate();
                 break;
             }
         }
 
+        configuration.validate();
         this.configuration.set(configuration);
 
         if (LOGGER.isLoggable(Level.INFO)) {

--- a/arquillian-recorder-reporter/arquillian-recorder-reporter-impl/src/main/java/org/arquillian/recorder/reporter/exporter/impl/HTMLExporter.java
+++ b/arquillian-recorder-reporter/arquillian-recorder-reporter-impl/src/main/java/org/arquillian/recorder/reporter/exporter/impl/HTMLExporter.java
@@ -148,30 +148,38 @@ public class HTMLExporter implements Exporter {
     private void normalizeFilePaths(Reportable report) {
         for (TestSuiteReport testSuiteReport : ((Report) report).getTestSuiteReports()) {
             for (PropertyEntry entry : testSuiteReport.getPropertyEntries()) {
-                if (entry instanceof VideoEntry) {
-                    VideoEntry e = (VideoEntry) entry;
-                    e.setLink(e.getPath().substring(configuration.getRootDir().getAbsolutePath().length() + 1));
-                }
+                    validatePath(entry);
             }
             for (TestClassReport testClassReport : testSuiteReport.getTestClassReports()) {
                 for (PropertyEntry entry : testClassReport.getPropertyEntries()) {
-                    if (entry instanceof VideoEntry) {
-                        VideoEntry e = (VideoEntry) entry;
-                        e.setLink(e.getPath().substring(configuration.getRootDir().getAbsolutePath().length() + 1));
-                    }
+                        validatePath(entry);
                 }
                 for (TestMethodReport testMethodReport : testClassReport.getTestMethodReports()) {
                     for (PropertyEntry entry : testMethodReport.getPropertyEntries()) {
-                        if (entry instanceof VideoEntry) {
-                            VideoEntry e = (VideoEntry) entry;
-                            e.setLink(e.getPath().substring(configuration.getRootDir().getAbsolutePath().length() + 1));
-                        } else if (entry instanceof ScreenshotEntry) {
-                            ScreenshotEntry e = (ScreenshotEntry) entry;
-                            e.setLink(e.getPath().substring(configuration.getRootDir().getAbsolutePath().length() + 1));
-                        }
+                            validatePath(entry);
                     }
                 }
             }
         }
     }
+
+    /**
+     * Validates if the file path is in absolute form and if so relativize it.
+     *
+     * @param entry
+    */
+    private void validatePath(PropertyEntry entry) {
+        if (entry instanceof VideoEntry) {
+            VideoEntry e = (VideoEntry) entry;
+            if (e.getPath().contains(configuration.getRootDir().getAbsolutePath())) {
+                e.setLink(e.getPath().substring(configuration.getRootDir().getAbsolutePath().length() + 1));
+            }
+        } else if (entry instanceof ScreenshotEntry) {
+            ScreenshotEntry e = (ScreenshotEntry) entry;
+            if (e.getPath().contains(configuration.getRootDir().getAbsolutePath())) {
+                e.setLink(e.getPath().substring(configuration.getRootDir().getAbsolutePath().length() + 1));
+            }
+        }
+    }
 }
+


### PR DESCRIPTION
#### Short description of what this resolves:

HTML Exporter resolves to wrong source path post file path normalization in the HTML for resources like videos and screenshots, if relativized path is provided. 
It should be able to handle both the absolute as well as relativized paths.

#### Changes proposed in this pull request:

- Validate if the given path is in absolute form and normalize if so. 

#### Screenshots

##### Before
![screenshot with incorrect link](https://cloud.githubusercontent.com/assets/8680543/21010263/18bd8f2e-bd71-11e6-85db-9411a97337da.png)

##### After
![screenshot with corrected link](https://cloud.githubusercontent.com/assets/8680543/21010264/18bfcee2-bd71-11e6-9f91-b798d673977b.png)

**Fixes**: #60 
