### PR TITLE
create rootDir including parent folders

### DIFF
--- a/arquillian-recorder-reporter/arquillian-recorder-reporter-api/src/main/java/org/arquillian/recorder/reporter/ReporterConfiguration.java
+++ b/arquillian-recorder-reporter/arquillian-recorder-reporter-api/src/main/java/org/arquillian/recorder/reporter/ReporterConfiguration.java
@@ -234,7 +234,7 @@ public class ReporterConfiguration extends Configuration<ReporterConfiguration> 
 
         try {
             if (!getRootDir().exists()) {
-                boolean created = getRootDir().mkdir();
+                boolean created = getRootDir().mkdirs();
                 if (!created) {
                     throw new ReporterConfigurationException("Unable to create root directory " + getRootDir().getAbsolutePath());
                 }

--- a/arquillian-recorder-screenshooter-base/arquillian-recorder-screenshooter-api/src/main/java/org/arquillian/extension/recorder/screenshooter/ScreenshooterConfiguration.java
+++ b/arquillian-recorder-screenshooter-base/arquillian-recorder-screenshooter-api/src/main/java/org/arquillian/extension/recorder/screenshooter/ScreenshooterConfiguration.java
@@ -128,7 +128,7 @@ public class ScreenshooterConfiguration extends Configuration<ScreenshooterConfi
 
         try {
             if (!getRootDir().exists()) {
-                boolean created = getRootDir().mkdir();
+                boolean created = getRootDir().mkdirs();
                 if (!created) {
                     throw new ScreenshooterConfigurationException("Unable to create root directory "
                         + getRootDir().getAbsolutePath());

--- a/arquillian-recorder-video-base/arquillian-recorder-video-api/src/main/java/org/arquillian/extension/recorder/video/VideoConfiguration.java
+++ b/arquillian-recorder-video-base/arquillian-recorder-video-api/src/main/java/org/arquillian/extension/recorder/video/VideoConfiguration.java
@@ -171,7 +171,7 @@ public class VideoConfiguration extends Configuration<VideoConfiguration> {
 
         try {
             if (!getRootDir().exists()) {
-                boolean created = getRootDir().mkdir();
+                boolean created = getRootDir().mkdirs();
                 if (!created) {
                     throw new VideoConfigurationException("Unable to create root directory " + getRootDir().getAbsolutePath());
                 }


### PR DESCRIPTION
**Fixes**:  #65 

Replaced `mkdir()` with `mkdirs()`.

Maybe this should be replaced by using the common org.arquillian.extension.recorder.RecorderFileUtils utility class in further releases?